### PR TITLE
fix: [node-typescript-compiler] error caused by child_process.spawn in win32 platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.idea

--- a/stack--current/4-tools/node-typescript-compiler/src/compile.js
+++ b/stack--current/4-tools/node-typescript-compiler/src/compile.js
@@ -15,6 +15,7 @@ const { set_banner, display_banner_if_1st_output } = require('./logger')
 
 const spawn_options = {
 	env: process.env,
+	shell: process.platform === 'win32',
 }
 const RADIX = EXECUTABLE
 


### PR DESCRIPTION
Hi, Offirmo. It seems like you forgot about this [issue](https://github.com/Offirmo/offirmo-monorepo/issues/5).
I complied with this problem based on this [suggestion](https://stackoverflow.com/questions/37459717/error-spawn-enoent-on-windows).
Please check it and release a new version of this tool. Thanks very much!